### PR TITLE
Fix for an extra null terminator appended to the time string

### DIFF
--- a/lib/src/ConnectionHelper.cpp
+++ b/lib/src/ConnectionHelper.cpp
@@ -74,6 +74,7 @@ string_t GetCurrentRequestTime()
 #ifdef _UTF16_STRINGS
 	string_t timeAsString(strlen(buf) + 1, U(' '));
 	mbstowcs_s(nullptr, &timeAsString[0], timeAsString.size(), buf, strlen(buf));
+	timeAsString.resize(wcslen(timeAsString.c_str()));
 #else
 	string_t timeAsString = string_t(buf);
 #endif


### PR DESCRIPTION
If the resulting string ends up being shorter than the maximum length, GetCurrentRequestTime() will include the null terminator in the actual size of the returned std::string (i.e. the null is treated as a part of the string rather than its terminator). As a consequence, when this string is concatenated with the HTTP headers far down the line in cpprest, the headers are cut short due to an extra null and the HTTP request fails. I ran into this behavior while debugging a project that is using DocumentDbCpp.

Truncating the string to the actual length of its contents fixes the issue in a safe manner because c_str() guarantees that another null terminator will be present after size() characters.